### PR TITLE
XRPL Transactions

### DIFF
--- a/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplPaymentTransaction.cs
+++ b/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplPaymentTransaction.cs
@@ -1,54 +1,62 @@
 ﻿using System.Text.Json.Serialization;
 using XUMM.NET.SDK.Enums;
 
-namespace XUMM.NET.SDK.Models.Payload.XRPL
+namespace XUMM.NET.SDK.Models.Payload.XRPL;
+
+public class XrplPaymentTransaction : XrplTransaction
 {
-    public class XrplPaymentTransaction : XrplTransaction
+    /// <summary>
+    /// A Payment transaction represents a transfer of value from one account to another. (Depending on the path taken, this can involve additional exchanges of value, which occur atomically.)
+    /// </summary>
+    /// <param name="destination">The unique address of the account receiving the payment.</param>
+    /// <param name="destinationTag">(Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.</param>
+    /// <param name="fee">Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.</param>
+    public XrplPaymentTransaction(string destination, int? destinationTag, int fee) : this()
     {
-        /// <summary>
-        /// A Payment transaction represents a transfer of value from one account to another. (Depending on the path taken, this can involve additional exchanges of value, which occur atomically.)
-        /// </summary>
-        /// <param name="destination">The unique address of the account receiving the payment.</param>
-        /// <param name="destinationTag">(Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.</param>
-        /// <param name="fee">Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.</param>
-        public XrplPaymentTransaction(string destination, int? destinationTag, int fee) : base(XrplTransactionType.Payment, fee)
-        {
-            Destination = destination;
-            DestinationTag = destinationTag;
-        }
-
-        /// <summary>
-        /// The unique address of the account receiving the payment.
-        /// </summary>
-        public string Destination { get; set; }
-
-        /// <summary>
-        /// (Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.
-        /// </summary>
-        public int? DestinationTag { get; set; }
-
-        /// <summary>
-        /// (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.
-        /// </summary>
-        [JsonPropertyName("InvoiceID")]
-        public string? InvoiceId { get; set; }
-
-        /// <summary>
-        /// The amount of currency to deliver. For non-XRP amounts, the nested field names MUST be lower-case. If the tfPartialPayment flag is set, deliver up to this amount instead.
-        /// </summary>
-        [JsonPropertyName("Amount")]
-        public XrplTransactionCurrencyAmount? Amount { get; set; }
-
-        /// <summary>
-        /// (Optional) Highest amount of source currency this transaction is allowed to cost, including transfer fees, exchange rates, and slippage.
-        /// </summary>
-        [JsonPropertyName("SendMax")]
-        public XrplTransactionCurrencyAmount? SendMax { get; set; }
-
-        /// <summary>
-        /// (Optional) Minimum amount of destination currency this transaction should deliver. Only valid if this is a partial payment.
-        /// </summary>
-        [JsonPropertyName("DeliverMin")]
-        public XrplTransactionCurrencyAmount? DeliverMin { get; set; }
+        Destination = destination;
+        DestinationTag = destinationTag;
+        Fee = fee.ToString();
     }
+
+    public XrplPaymentTransaction()
+    {
+        TransactionType = XrplTransactionType.Payment.ToString();
+    }
+
+    /// <summary>
+    /// The unique address of the account receiving the payment.
+    /// </summary>
+    public string Destination { get; set; }
+
+    /// <summary>
+    /// (Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.
+    /// </summary>
+    public int? DestinationTag { get; set; }
+
+    /// <summary>
+    /// (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.
+    /// </summary>
+    [JsonPropertyName("InvoiceID")]
+    public string? InvoiceId { get; set; }
+
+    /// <summary>
+    /// The amount of currency to deliver. For non-XRP amounts, the nested field names MUST be lower-case. If the
+    /// tfPartialPayment flag is set, deliver up to this amount instead.
+    /// </summary>
+    [JsonPropertyName("Amount")]
+    public XrplTransactionCurrencyAmount? Amount { get; set; }
+
+    /// <summary>
+    /// (Optional) Highest amount of source currency this transaction is allowed to cost, including transfer fees, exchange
+    /// rates, and slippage.
+    /// </summary>
+    [JsonPropertyName("SendMax")]
+    public XrplTransactionCurrencyAmount? SendMax { get; set; }
+
+    /// <summary>
+    /// (Optional) Minimum amount of destination currency this transaction should deliver. Only valid if this is a partial
+    /// payment.
+    /// </summary>
+    [JsonPropertyName("DeliverMin")]
+    public XrplTransactionCurrencyAmount? DeliverMin { get; set; }
 }

--- a/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplTransaction.cs
+++ b/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplTransaction.cs
@@ -1,54 +1,46 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using XUMM.NET.SDK.Enums;
 
-namespace XUMM.NET.SDK.Models.Payload.XRPL
+namespace XUMM.NET.SDK.Models.Payload.XRPL;
+
+public class XrplTransaction
 {
-    public class XrplTransaction
-    {
-        public XrplTransaction(XrplTransactionType transactionType, int fee)
-        {
-            TransactionType = transactionType.ToString();
-            Fee = fee.ToString();
-        }
+    [JsonPropertyName("Account")]
+    public string? Account { get; set; }
 
-        [JsonPropertyName("Account")]
-        public string? Account { get; set; }
+    [JsonPropertyName("TransactionType")]
+    public string TransactionType { get; set; }
 
-        [JsonPropertyName("TransactionType")]
-        public string TransactionType { get; set; }
+    [JsonPropertyName("Fee")]
+    public string Fee { get; set; }
 
-        [JsonPropertyName("Fee")]
-        public string Fee { get; }
+    [JsonPropertyName("Sequence")]
+    public int? Sequence { get; set; }
 
-        [JsonPropertyName("Sequence")]
-        public int? Sequence { get; set; }
+    [JsonPropertyName("AccountTxnID")]
+    public string? AccountTxnId { get; set; }
 
-        [JsonPropertyName("AccountTxnID")]
-        public string? AccountTxnId { get; set; }
+    [JsonPropertyName("Flags")]
+    public int? Flags { get; set; }
 
-        [JsonPropertyName("Flags")]
-        public int? Flags { get; set; }
+    [JsonPropertyName("LastLedgerSequence")]
+    public int? LastLedgerSequence { get; set; }
 
-        [JsonPropertyName("LastLedgerSequence")]
-        public int? LastLedgerSequence { get; set; }
+    [JsonPropertyName("Memos")]
+    public List<XrplTransactionMemoField>? Memos { get; set; }
 
-        [JsonPropertyName("Memos")]
-        public List<XrplTransactionMemoField>? Memos { get; set; }
+    [JsonPropertyName("Signers")]
+    public List<XrplTransactionSignerField>? Signers { get; set; }
 
-        [JsonPropertyName("Signers")]
-        public List<XrplTransactionSignerField>? Signers { get; set; }
+    [JsonPropertyName("SourceTag")]
+    public int? SourceTag { get; set; }
 
-        [JsonPropertyName("SourceTag")]
-        public int? SourceTag { get; set; }
+    [JsonPropertyName("SigningPubKey")]
+    public string? SigningPubKey { get; set; }
 
-        [JsonPropertyName("SigningPubKey")]
-        public string? SigningPubKey { get; set; }
+    [JsonPropertyName("TicketSequence")]
+    public int? TicketSequence { get; set; }
 
-        [JsonPropertyName("TicketSequence")]
-        public int? TicketSequence { get; set; }
-
-        [JsonPropertyName("TxnSignature")]
-        public string? TxnSignature { get; set; }
-    }
+    [JsonPropertyName("TxnSignature")]
+    public string? TxnSignature { get; set; }
 }

--- a/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplTrustSetLimitAmount.cs
+++ b/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplTrustSetLimitAmount.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+
+namespace XUMM.NET.SDK.Models.Payload.XRPL;
+
+/// <summary>
+/// Object defining the trust line to create or modify, in the format of a Currency Amount.
+/// </summary>
+public class XrplTrustSetLimitAmount
+{
+    /// <summary>
+    /// The currency to this trust line applies to, as a three-letter ISO 4217 Currency Code  or a 160-bit hex value according
+    /// to currency format. "XRP" is invalid.
+    /// </summary>
+    [JsonPropertyName("currency")]
+    public string Currency { get; set; } = default!;
+
+    /// <summary>
+    /// Quoted decimal representation of the limit to set on this trust line.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = default!;
+
+    /// <summary>
+    /// The address of the account to extend trust to.
+    /// </summary>
+    [JsonPropertyName("issuer")]
+    public string Issuer { get; set; } = default!;
+}

--- a/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplTrustSetTransaction.cs
+++ b/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplTrustSetTransaction.cs
@@ -1,0 +1,40 @@
+﻿using System.Text.Json.Serialization;
+using XUMM.NET.SDK.Enums;
+
+namespace XUMM.NET.SDK.Models.Payload.XRPL;
+
+public class XrplTrustSetTransaction : XrplTransaction
+{
+    /// <param name="account">The unique address of the account that initiated the transaction.</param>
+    /// <param name="currency">
+    /// The currency to this trust line applies to, as a three-letter ISO 4217 Currency Code or a
+    /// 160-bit hex value according to currency format. "XRP" is invalid.
+    /// </param>
+    /// <param name="issuer">The address of the account to extend trust to.</param>
+    /// <param name="value">Quoted decimal representation of the limit to set on this trust line.</param>
+    /// <param name="fee">
+    /// Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.
+    /// </param>
+    public XrplTrustSetTransaction(string account, string currency, string issuer, string value, int fee) : this()
+    {
+        Account = account;
+        LimitAmount = new XrplTrustSetLimitAmount
+        {
+            Currency = currency,
+            Issuer = issuer,
+            Value = value
+        };
+        Fee = fee.ToString();
+    }
+
+    public XrplTrustSetTransaction()
+    {
+        TransactionType = XrplTransactionType.TrustSet.ToString();
+    }
+
+    /// <summary>
+    /// Object defining the trust line to create or modify, in the format of a Currency Amount.
+    /// </summary>
+    [JsonPropertyName("LimitAmount")]
+    public XrplTrustSetLimitAmount LimitAmount { get; set; }
+}


### PR DESCRIPTION
Added parameterless constructors te be able to deserialize XRPL transactions without immutable converters for different .NET Frameworks without custom implementations for JsonConstructor.