### PR TITLE
GET account-meta/:account

### DIFF
--- a/examples/XUMM.NET.ServerApp/Pages/Misc/AccountMeta.razor
+++ b/examples/XUMM.NET.ServerApp/Pages/Misc/AccountMeta.razor
@@ -4,6 +4,7 @@
 @using XUMM.NET.SDK.Models.Misc
 @using XUMM.NET.ServerApp.Extensions
 
+@inject IOptions<XrplConfig> Config
 @inject IXummMiscClient _miscClient
 
 <PageTitle>Account Meta</PageTitle>
@@ -17,7 +18,7 @@
         <div class="row">
             <div class="mb-3">
                 <label for="account" class="form-label">Account</label>
-                <input id="account" type="text" class="form-control" placeholder="Account address, eg. rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB" aria-label="Account" aria-describedby="basic-addon2" @bind="_account">
+                <input id="account" type="text" class="form-control" placeholder="Account address, eg. @Config.Value.Account" aria-label="Account" aria-describedby="basic-addon2" @bind="_account">
             </div>
             <div class="btn-group mb-3" role="group">
                 <button class="btn btn-primary" type="button" @onclick="GetAccountMetaAsync">Fetch Account Meta</button>
@@ -49,7 +50,7 @@
                         </dl>
                     }
 
-                    @if (_accountMeta.GlobaliD != null)
+                    @if (_accountMeta.GlobaliD?.ProfileUrl != null && _accountMeta.GlobaliD?.Linked != null)
                     {
                         <h2>GlobaliD</h2>
                         <dl class="row">
@@ -106,8 +107,7 @@
     {
         if (!_account.IsAccountAddress())
         {
-            // TODO: Set an example account with account meta
-            return;
+            _account = Config.Value.Account;
         }
 
         _accountMeta = await _responseAlertBox.GetResponseAndSetAlertAsync(() => _miscClient.AccountMetaAsync(_account));

--- a/examples/XUMM.NET.ServerApp/Pages/Misc/AccountMeta.razor
+++ b/examples/XUMM.NET.ServerApp/Pages/Misc/AccountMeta.razor
@@ -1,0 +1,116 @@
+﻿@page "/account-meta"
+@using XUMM.NET.SDK.Clients.Interfaces
+@using XUMM.NET.SDK.Extensions
+@using XUMM.NET.SDK.Models.Misc
+@using XUMM.NET.ServerApp.Extensions
+
+@inject IXummMiscClient _miscClient
+
+<PageTitle>Account Meta</PageTitle>
+
+<ResponseAlertBox @ref="_responseAlertBox"></ResponseAlertBox>
+
+<h1>Account Meta</h1>
+
+<div class="row align-items-start">
+    <div class="col-md-6">
+        <div class="row">
+            <div class="mb-3">
+                <label for="account" class="form-label">Account</label>
+                <input id="account" type="text" class="form-control" placeholder="Account address, eg. rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB" aria-label="Account" aria-describedby="basic-addon2" @bind="_account">
+            </div>
+            <div class="btn-group mb-3" role="group">
+                <button class="btn btn-primary" type="button" @onclick="GetAccountMetaAsync">Fetch Account Meta</button>
+            </div>
+        </div>
+
+        @if (_accountMeta != null)
+        {
+            <div class="row">
+                <div class="mb-3">
+                    <h2>Account Meta</h2>
+                    <dl class="row">
+                        <dt class="col-6">Account</dt>
+                        <dd class="col-6 text-break">@_accountMeta.Account</dd>
+                        <dt class="col-6">KYC Approved</dt>
+                        <dd class="col-6 text-break">@(_accountMeta.KycApproved ? "Yes" : "No")</dd>
+                        <dt class="col-6">XUMM Pro</dt>
+                        <dd class="col-6 text-break">@(_accountMeta.XummPro ? "Yes" : "No")</dd>
+                    </dl>
+                    
+                    @if (_accountMeta.XummProfile != null)
+                    {
+                        <h2>XUMM Profile</h2>
+                        <dl class="row">
+                            <dt class="col-6">Account Alias</dt>
+                            <dd class="col-6 text-break">@_accountMeta.XummProfile.AccountAlias</dd>
+                            <dt class="col-6">Owner Alias</dt>
+                            <dd class="col-6 text-break">@_accountMeta.XummProfile.OwnerAlias</dd>
+                        </dl>
+                    }
+
+                    @if (_accountMeta.GlobaliD != null)
+                    {
+                        <h2>GlobaliD</h2>
+                        <dl class="row">
+                            <dt class="col-6">Profile URL</dt>
+                            <dd class="col-6 text-break"><a href="@_accountMeta.GlobaliD.ProfileUrl" target="_blank">@_accountMeta.GlobaliD.ProfileUrl</a></dd>
+                            <dt class="col-6">Linked</dt>
+                            <dd class="col-6 text-break">@_accountMeta.GlobaliD.Linked</dd>
+                        </dl>
+                    }
+
+                    @if (_accountMeta.ThirdPartyProfiles.Any())
+                    {
+                        <h2>Third Party Profiles</h2>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Source</th>
+                                    <th scope="col">Account Alias</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var thirdPartyProfile in _accountMeta.ThirdPartyProfiles.OrderBy(x => x.Source))
+                                {
+                                    <tr>
+                                        <th scope="row">@thirdPartyProfile.Source</th>
+                                        <td>@thirdPartyProfile.AccountAlias</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+        <div class="col-md-6 text-center">
+        @if (_accountMeta?.Avatar != null)
+        {
+            <div class="input-group mb-3">
+                <figure class="figure">
+                    <img src="@_accountMeta.Avatar" class="figure-img img-fluid rounded" alt="Avatar of account @_account">
+                    <figcaption class="figure-caption text-break">@_accountMeta.Avatar</figcaption>
+                </figure>
+            </div>
+        }
+    </div>
+</div>
+@code {
+    private ResponseAlertBox _responseAlertBox = default!;
+    private string _account = default!;
+    private XummAccountMetaResponse? _accountMeta;
+
+    private async Task GetAccountMetaAsync()
+    {
+        if (!_account.IsAccountAddress())
+        {
+            // TODO: Set an example account with account meta
+            return;
+        }
+
+        _accountMeta = await _responseAlertBox.GetResponseAndSetAlertAsync(() => _miscClient.AccountMetaAsync(_account));
+        _responseAlertBox.SetAlert("Account Meta", _accountMeta != null);
+    }
+}

--- a/examples/XUMM.Net.ServerApp/Shared/NavMenu.razor
+++ b/examples/XUMM.Net.ServerApp/Shared/NavMenu.razor
@@ -38,6 +38,9 @@
                 <NavLink class="nav-link ps-4" href="/user-tokens">
                     <span class="oi oi-key" aria-hidden="true"></span> User Tokens
                 </NavLink>
+                <NavLink class="nav-link ps-4" href="/account-meta">
+                    <span class="oi oi-copywriting" aria-hidden="true"></span> Account Meta
+                </NavLink>
                 <NavLink class="nav-link ps-4" href="/avatar">
                     <span class="oi oi-image" aria-hidden="true"></span> Avatar
                 </NavLink>

--- a/src/XUMM.NET.SDK.Tests/Clients/XummMiscClientTests.cs
+++ b/src/XUMM.NET.SDK.Tests/Clients/XummMiscClientTests.cs
@@ -284,7 +284,7 @@ public class XummMiscClientTests
     }
 
     [Test]
-    [TestCase("rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB")]
+    [TestCase("qrBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
     public async Task GetAccountMetaAsync_WithValidAccount_ShouldReturnAccountMetaAsync(string account)
     {
         // Arrange
@@ -298,7 +298,7 @@ public class XummMiscClientTests
     }
 
     [Test]
-    [TestCase("rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB")]
+    [TestCase("qrBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
     public async Task GetAccountMetaAsync_WithValidAccount_ShouldContainAccountInRequestUriAsync(string account)
     {
         // Arrange
@@ -312,7 +312,7 @@ public class XummMiscClientTests
     }
 
     [Test]
-    [TestCase("qrDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB")]
+    [TestCase("qrBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
     public void GetAccountMetaAsync_WithInvalidAccount_ShouldThrowExceptionAsync(string account)
     {
         // Act

--- a/src/XUMM.NET.SDK.Tests/Clients/XummMiscClientTests.cs
+++ b/src/XUMM.NET.SDK.Tests/Clients/XummMiscClientTests.cs
@@ -192,7 +192,7 @@ public class XummMiscClientTests
         _httpMessageHandlerMock.SetFixtureMessage(HttpStatusCode.OK, "xrpltx");
 
         // Act
-        var result = await _subject.GetTransactionAsync(txHash);
+        _ = await _subject.GetTransactionAsync(txHash);
 
         // Assert
         _httpMessageHandlerMock.AssertRequestUri(HttpMethod.Get, $"/xrpl-tx/{txHash}");
@@ -234,7 +234,7 @@ public class XummMiscClientTests
         _httpMessageHandlerMock.SetFixtureMessage(HttpStatusCode.OK, "user-token");
 
         // Act
-        var result = await _subject.VerifyUserTokenAsync(userToken);
+        _ = await _subject.VerifyUserTokenAsync(userToken);
 
         // Assert
         _httpMessageHandlerMock.AssertRequestUri(HttpMethod.Get, $"/user-token/{userToken}");
@@ -281,6 +281,46 @@ public class XummMiscClientTests
         // Assert
         Assert.IsNotNull(ex);
         Assert.That(ex!.Message, Is.EqualTo("Value cannot be null or empty (Parameter 'userTokens')"));
+    }
+
+    [Test]
+    [TestCase("rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB")]
+    public async Task GetAccountMetaAsync_WithValidAccount_ShouldReturnAccountMetaAsync(string account)
+    {
+        // Arrange
+        _httpMessageHandlerMock.SetFixtureMessage(HttpStatusCode.OK, "account-meta");
+
+        // Act
+        var result = await _subject.AccountMetaAsync(account);
+
+        // Assert
+        AssertExtensions.AreEqual(MiscFixtures.XummAccountMeta, result);
+    }
+
+    [Test]
+    [TestCase("rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB")]
+    public async Task GetAccountMetaAsync_WithValidAccount_ShouldContainAccountInRequestUriAsync(string account)
+    {
+        // Arrange
+        _httpMessageHandlerMock.SetFixtureMessage(HttpStatusCode.OK, "account-meta");
+
+        // Act
+        _ = await _subject.AccountMetaAsync(account);
+
+        // Assert
+        _httpMessageHandlerMock.AssertRequestUri(HttpMethod.Get, $"/account-meta/{account}");
+    }
+
+    [Test]
+    [TestCase("qrDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB")]
+    public void GetAccountMetaAsync_WithInvalidAccount_ShouldThrowExceptionAsync(string account)
+    {
+        // Act
+        var ex = Assert.ThrowsAsync<ArgumentException>(() => _subject.AccountMetaAsync(account));
+
+        // Assert
+        Assert.IsNotNull(ex);
+        Assert.That(ex!.Message, Is.EqualTo("Value should be a valid account address (Parameter 'account')"));
     }
 
     [Test]

--- a/src/XUMM.NET.SDK.Tests/Clients/XummMiscClientTests.cs
+++ b/src/XUMM.NET.SDK.Tests/Clients/XummMiscClientTests.cs
@@ -284,7 +284,7 @@ public class XummMiscClientTests
     }
 
     [Test]
-    [TestCase("qrBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
+    [TestCase("rBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
     public async Task GetAccountMetaAsync_WithValidAccount_ShouldReturnAccountMetaAsync(string account)
     {
         // Arrange
@@ -298,7 +298,7 @@ public class XummMiscClientTests
     }
 
     [Test]
-    [TestCase("qrBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
+    [TestCase("rBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q")]
     public async Task GetAccountMetaAsync_WithValidAccount_ShouldContainAccountInRequestUriAsync(string account)
     {
         // Arrange

--- a/src/XUMM.NET.SDK.Tests/Data/account-meta.json
+++ b/src/XUMM.NET.SDK.Tests/Data/account-meta.json
@@ -1,0 +1,24 @@
+﻿{
+  "account": "rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ",
+  "kycApproved": true,
+  "xummPro": true,
+  "avatar": "https://xumm.app/avatar/rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ.png",
+  "xummProfile": {
+    "accountAlias": "XRPL Labs - Wietse Wind",
+    "ownerAlias": "Wietse Wind"
+  },
+  "thirdPartyProfiles": [
+    {
+      "accountAlias": "Wietse Wind",
+      "source": "xumm.app"
+    },
+    {
+      "accountAlias": "wietse.com",
+      "source": "xrpl"
+    }
+  ],
+  "globalid": {
+    "linked": "2021-06-29T10:22:25.123Z",
+    "profileUrl": "https://global.id/wietse"
+  }
+}

--- a/src/XUMM.NET.SDK.Tests/Fixtures/MiscFixtures.cs
+++ b/src/XUMM.NET.SDK.Tests/Fixtures/MiscFixtures.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using XUMM.NET.SDK.Models.Misc;
 
@@ -184,6 +185,37 @@ internal static class MiscFixtures
                 UserToken = "b12b59a8-83c8-4bc0-8acb-1d1d743871f1",
                 Active = false
             }
+        }
+    };
+
+    internal static XummAccountMetaResponse XummAccountMeta => new()
+    {
+        Account = "rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ",
+        KycApproved = true,
+        XummPro = true,
+        Avatar = "https://xumm.app/avatar/rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ.png",
+        XummProfile = new()
+        {
+            AccountAlias = "XRPL Labs - Wietse Wind",
+            OwnerAlias = "Wietse Wind"
+        },
+        ThirdPartyProfiles = new()
+        {
+            new XummThirdPartyProfile()
+            {
+                AccountAlias="Wietse Wind",
+                Source= "xumm.app"
+            },
+            new XummThirdPartyProfile()
+            {
+                AccountAlias= "wietse.com",
+                Source= "xrpl"
+            }
+        },
+        GlobaliD = new()
+        {
+            Linked = new DateTime(2021, 06, 29, 10, 22, 25, 123, DateTimeKind.Utc),
+            ProfileUrl = "https://global.id/wietse"
         }
     };
 }

--- a/src/XUMM.NET.SDK.Tests/XUMM.NET.SDK.Tests.csproj
+++ b/src/XUMM.NET.SDK.Tests/XUMM.NET.SDK.Tests.csproj
@@ -6,8 +6,11 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <Content Include="Data\account-meta.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Data\user-tokens.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/XUMM.NET.SDK/Clients/Interfaces/IXummMiscClient.cs
+++ b/src/XUMM.NET.SDK/Clients/Interfaces/IXummMiscClient.cs
@@ -46,6 +46,12 @@ public interface IXummMiscClient
     Task<XummUserTokens> VerifyUserTokensAsync(string[] userTokens);
 
     /// <summary>
+    /// Fetch the account meta for a XUMM user (based on a public XRPL account address, r...)
+    /// </summary>
+    /// <param name="account">Account address, eg. rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB</param>
+    Task<XummAccountMetaResponse> AccountMetaAsync(string account);
+
+    /// <summary>
     /// Get an avatar (gravatar or personal avatar)
     /// </summary>
     /// <param name="account">Account address, eg. rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB</param>

--- a/src/XUMM.NET.SDK/Clients/Interfaces/IXummMiscClient.cs
+++ b/src/XUMM.NET.SDK/Clients/Interfaces/IXummMiscClient.cs
@@ -15,7 +15,7 @@ public interface IXummMiscClient
     Task<XummCuratedAssets> GetCuratedAssetsAsync();
 
     /// <summary>
-    /// Fetch transaction & outcome live from XRP ledger full history nodes (through the XUMM platform) containing parsed
+    /// Fetch transaction and outcome live from XRP ledger full history nodes (through the XUMM platform) containing parsed
     /// transaction outcome balance mutations
     /// </summary>
     /// <param name="txHash">The transaction hash (64 hexadecimal characters)</param>
@@ -48,7 +48,7 @@ public interface IXummMiscClient
     /// <summary>
     /// Fetch the account meta for a XUMM user (based on a public XRPL account address, r...)
     /// </summary>
-    /// <param name="account">Account address, eg. rDWLGshgAxSX2G4TEv3gA6QhtLgiXrWQXB</param>
+    /// <param name="account">Account address, eg. rBLomsmaSJ1ttBmS3WPmPpWLAUDKFwiF9Q</param>
     Task<XummAccountMetaResponse> AccountMetaAsync(string account);
 
     /// <summary>

--- a/src/XUMM.NET.SDK/Clients/XummMiscClient.cs
+++ b/src/XUMM.NET.SDK/Clients/XummMiscClient.cs
@@ -109,6 +109,17 @@ public class XummMiscClient : IXummMiscClient
     }
 
     /// <inheritdoc />
+    public async Task<XummAccountMetaResponse> AccountMetaAsync(string account)
+    {
+        if (!account.IsAccountAddress())
+        {
+            throw new ArgumentException("Value should be a valid account address", nameof(account));
+        }
+
+        return await _httpClient.GetAsync<XummAccountMetaResponse>($"account-meta/{account}");
+    }
+
+    /// <inheritdoc />
     public string GetAvatarUrl(string account, int dimensions, int padding)
     {
         if (string.IsNullOrWhiteSpace(account))

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummAccountMetaResponse.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummAccountMetaResponse.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace XUMM.NET.SDK.Models.Misc
+{
+    public class XummAccountMetaResponse
+    {
+        [JsonPropertyName("account")]
+        public string Account { get; set; } = default!;
+
+        [JsonPropertyName("kycApproved")]
+        public bool KycApproved { get; set; }
+
+        [JsonPropertyName("xummPro")]
+        public bool XummPro { get; set; }
+
+        [JsonPropertyName("avatar")]
+        public string? Avatar { get; set; }
+
+        [JsonPropertyName("xummProfile")]
+        public XummProfile? XummProfile { get; set; } 
+
+        [JsonPropertyName("thirdPartyProfiles")]
+        public List<XummThirdPartyProfile> ThirdPartyProfiles { get; set; } = new List<XummThirdPartyProfile>();
+
+        [JsonPropertyName("globalid")]
+        public XummGlobaliD? GlobaliD { get; set; }
+    }
+}

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummAccountMetaResponse.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummAccountMetaResponse.cs
@@ -15,15 +15,15 @@ namespace XUMM.NET.SDK.Models.Misc
         public bool XummPro { get; set; }
 
         [JsonPropertyName("avatar")]
-        public string? Avatar { get; set; }
+        public string Avatar { get; set; } = default!;
 
         [JsonPropertyName("xummProfile")]
-        public XummProfile? XummProfile { get; set; } 
+        public XummProfile XummProfile { get; set; } = default!;
 
         [JsonPropertyName("thirdPartyProfiles")]
         public List<XummThirdPartyProfile> ThirdPartyProfiles { get; set; } = new List<XummThirdPartyProfile>();
 
         [JsonPropertyName("globalid")]
-        public XummGlobaliD? GlobaliD { get; set; }
+        public XummGlobaliD GlobaliD { get; set; } = default!;
     }
 }

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummGlobaliD.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummGlobaliD.cs
@@ -6,9 +6,9 @@ namespace XUMM.NET.SDK.Models.Misc
     public class XummGlobaliD
     {
         [JsonPropertyName("linked")]
-        public DateTime Linked { get; set; }
+        public DateTime? Linked { get; set; }
 
         [JsonPropertyName("profileUrl")]
-        public string ProfileUrl { get; set; } = default!;
+        public string? ProfileUrl { get; set; }
     }
 }

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummGlobaliD.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummGlobaliD.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace XUMM.NET.SDK.Models.Misc
+{
+    public class XummGlobaliD
+    {
+        [JsonPropertyName("linked")]
+        public DateTime Linked { get; set; }
+
+        [JsonPropertyName("profileUrl")]
+        public string ProfileUrl { get; set; } = default!;
+    }
+}

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummProfile.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummProfile.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace XUMM.NET.SDK.Models.Misc
+{
+    public class XummProfile
+    {
+        [JsonPropertyName("accountAlias")]
+        public string AccountAlias { get; set; } = default!;
+
+        [JsonPropertyName("ownerAlias")]
+        public string OwnerAlias { get; set; } = default!;
+    }
+}

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummProfile.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummProfile.cs
@@ -5,9 +5,9 @@ namespace XUMM.NET.SDK.Models.Misc
     public class XummProfile
     {
         [JsonPropertyName("accountAlias")]
-        public string AccountAlias { get; set; } = default!;
+        public string? AccountAlias { get; set; }
 
         [JsonPropertyName("ownerAlias")]
-        public string OwnerAlias { get; set; } = default!;
+        public string? OwnerAlias { get; set; }
     }
 }

--- a/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummThirdPartyProfile.cs
+++ b/src/XUMM.NET.SDK/Models/Misc/AccountMeta/XummThirdPartyProfile.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace XUMM.NET.SDK.Models.Misc
+{
+    public class XummThirdPartyProfile
+    {
+        [JsonPropertyName("accountAlias")]
+        public string AccountAlias { get; set; } = default!;
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; } = default!;
+    }
+}


### PR DESCRIPTION
Added `AccountMetaAsync` to `IXummMiscClient` for the retrieval of account meta based on an XRPL Account address (r-address).
A component has been added to the example ServerApp.

 Documentation: [GET https://xumm.app/api/v1/platform/account-meta/{account}](https://xumm.readme.io/reference/account-metaaccount)