### PR TITLE
JsonStringEnumConverter removal

### DIFF
--- a/examples/XUMM.NET.ServerApp/Pages/Misc/UserTokens.razor
+++ b/examples/XUMM.NET.ServerApp/Pages/Misc/UserTokens.razor
@@ -57,6 +57,11 @@
 
     private async Task VerifyUserTokensAsync()
     {
+        if (string.IsNullOrWhiteSpace(_userTokens))
+        {
+            return;
+        }
+
         var userTokens = Regex.Replace(_userTokens, @"\r\n?|\n", "\r").Split('\r', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         if (userTokens.Length == 0)
         {

--- a/examples/XUMM.Net.ServerApp/Pages/Payload/SignIn.razor
+++ b/examples/XUMM.Net.ServerApp/Pages/Payload/SignIn.razor
@@ -4,6 +4,7 @@
 @using Microsoft.Extensions.Caching.Memory
 @using XUMM.NET.SDK.Clients.Interfaces
 @using XUMM.NET.SDK.Enums
+@using XUMM.NET.SDK.Extensions
 @using XUMM.NET.SDK.WebSocket.EventArgs
 @using XUMM.NET.SDK.Models.Payload
 @using XUMM.NET.SDK.Models.Payload.Xumm
@@ -126,12 +127,8 @@
 
     private async Task CreatePayloadAndSubscribe()
     {
-        var serializerOptions = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
-
-        var payload = new XummPostJsonPayload(JsonSerializer.Serialize(new XummPayloadTransaction(XummTransactionType.SignIn), serializerOptions))
-            {
-                CustomMeta = new XummPayloadCustomMeta { Instruction = "Test payload created with the XUMM.NET SDK." }
-            };
+        var payload = new XummPayloadTransaction(XummTransactionType.SignIn).ToXummPostJsonPayload();
+        payload.CustomMeta = new XummPayloadCustomMeta { Instruction = "Test payload created with the XUMM.NET SDK." };
 
         if (!string.IsNullOrWhiteSpace(_customIdentifier))
         {

--- a/src/XUMM.NET.SDK/Helpers/JsonHelper.cs
+++ b/src/XUMM.NET.SDK/Helpers/JsonHelper.cs
@@ -8,14 +8,10 @@ namespace XUMM.NET.SDK.Helpers
         internal static JsonSerializerOptions SerializerOptions => new JsonSerializerOptions
         {
 #if NET5_0_OR_GREATER
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
 #else
-            IgnoreNullValues = true,
+            IgnoreNullValues = true
 #endif
-            Converters =
-            {
-                new JsonStringEnumConverter()
-            }
         };
     }
 }


### PR DESCRIPTION
Removed `JsonStringEnumConverter` in `JsonSerializerOptions` because enums should not be as a string representation.