### PR TITLE
Destination Tag as unsigned integer

### DIFF
--- a/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplPaymentTransaction.cs
+++ b/src/XUMM.NET.SDK/Models/Payload/XRPL/XrplPaymentTransaction.cs
@@ -13,7 +13,7 @@ public class XrplPaymentTransaction : XrplTransaction
     /// <param name="destination">The unique address of the account receiving the payment.</param>
     /// <param name="destinationTag">(Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.</param>
     /// <param name="fee">Integer amount of XRP, in drops, to be destroyed as a cost for distributing this transaction to the network.</param>
-    public XrplPaymentTransaction(string destination, int? destinationTag, int fee) : this()
+    public XrplPaymentTransaction(string destination, uint? destinationTag, int fee) : this()
     {
         Destination = destination;
         DestinationTag = destinationTag;
@@ -39,7 +39,7 @@ public class XrplPaymentTransaction : XrplTransaction
     /// <summary>
     /// (Optional) Arbitrary tag that identifies the reason for the payment to the destination, or a hosted recipient to pay.
     /// </summary>
-    public int? DestinationTag { get; set; }
+    public uint? DestinationTag { get; set; }
 
     /// <summary>
     /// (Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.

--- a/src/XUMM.NET.SDK/Models/Payload/XummPayloadDetailsPayloadResponse.cs
+++ b/src/XUMM.NET.SDK/Models/Payload/XummPayloadDetailsPayloadResponse.cs
@@ -13,7 +13,7 @@ namespace XUMM.NET.SDK.Models.Payload
         public string TxDestination { get; set; } = default!;
 
         [JsonPropertyName("tx_destination_tag")]
-        public int? TxDestinationTag { get; set; }
+        public uint? TxDestinationTag { get; set; }
 
         [JsonPropertyName("request_json")]
         public JsonDocument RequestJson { get; set; } = default!;


### PR DESCRIPTION
The Destination Tag should've been of the type `uint` instead of `int` because in transactions, both source and destination tags are formatted as 32-bit unsigned integers.

https://xrpl.org/source-and-destination-tags.html